### PR TITLE
refactor: stop spinner before logging and restart after

### DIFF
--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -3,49 +3,65 @@ import chalk from "chalk";
 import { BaseCommand } from "../base-commands/BaseCommand.js";
 import { FATAL_ERROR_NUMBER } from "./constants.js";
 
+function withSpinner(ctx: BaseCommand, fn: () => void) {
+    const wasSpinning = ctx.spinner.isSpinning;
+    if (wasSpinning) {
+        ctx.spinner.stop();
+    }
+
+    fn();
+    if (wasSpinning) {
+        ctx.spinner.start();
+    }
+}
+
 /**
  * Info logs (normal operation).
  */
 export function log(ctx: BaseCommand, message: string): void {
-    ctx.spinner.stop()
-    ctx.log(`${chalk.cyan.bold("ℹ️  INFO:")} ${message}`);
+    withSpinner(ctx, () => {
+        ctx.log(`${chalk.cyan.bold("ℹ️  INFO:")} ${message}`);
+    });
 }
 
 /**
- * Warning logs (something might be wrong).
+ * Warning logs.
  */
 export function warn(ctx: BaseCommand, message: string): void {
-    ctx.spinner.stop()
-
-    ctx.log(`${chalk.yellow.bold("⚠️  WARN:")} ${chalk.yellow(message)}`);
+    withSpinner(ctx, () => {
+        ctx.log(`${chalk.yellow.bold("⚠️  WARN:")} ${chalk.yellow(message)}`);
+    });
 }
 
 /**
- * Error logs (non-fatal, execution continues).
+ * Error logs.
  */
 export function error(ctx: BaseCommand, message: string): void {
-    ctx.spinner.stop()
-    ctx.log(`${chalk.red.bold("❌ ERROR:")} ${chalk.red(message)}`);
+    withSpinner(ctx, () => {
+        ctx.log(`${chalk.red.bold("❌ ERROR:")} ${chalk.red(message)}`);
+    });
 }
 
 /**
- * Fatal error logs (terminates command, never returns).
+ * Fatal error logs (terminates command).
  */
 export function fatal(ctx: BaseCommand, message: string): never {
-    ctx.spinner.stop()
-    ctx.log(`${chalk.red.bold("💥 FATAL:")} ${chalk.red(message)}`);
+    withSpinner(ctx, () => {
+        ctx.log(`${chalk.red.bold("💥 FATAL:")} ${chalk.red(message)}`);
+    });
 
     return ctx.exit(FATAL_ERROR_NUMBER);
 }
 
 /**
- * Debug logs (only shown when the `--debug` flag is set).
+ * Debug logs.
  */
 export function debug(ctx: BaseCommand, message: string) {
     if (!ctx.argv.includes('--debug')) {
-        return;
+        return
     }
 
-    ctx.spinner.stop()
-    ctx.log(`${chalk.blue.bold("\u{1F50D} DEBUG:")} ${chalk.gray(message)}`);
+    withSpinner(ctx, () => {
+        ctx.log(`${chalk.blue.bold("\u{1F50D} DEBUG:")} ${chalk.gray(message)}`);
+    });
 }


### PR DESCRIPTION
- add `withSpinner` helper to manage spinner state
- use helper in `log` to prevent spinner from persisting during messages
- simplify comment sections for warning, error, fatal, and debug logs