### PR TITLE
refactor: replace simpleGit imports with getSimpleGit singleton

### DIFF
--- a/src/commands/auto-branch/index.ts
+++ b/src/commands/auto-branch/index.ts
@@ -1,6 +1,5 @@
 import { Args } from "@oclif/core";
 import chalk from "chalk";
-import { simpleGit } from "simple-git";
 
 import { BaseCommand } from "../../base-commands/BaseCommand.js";
 import { getService } from "../../services/index.js";
@@ -13,6 +12,7 @@ import { saveGatheredSettings } from "../../utils/config/saveGatheredSettings.js
 import { loadMergedUserConfig } from "../../utils/config/userConfigHelpers.js";
 import { gatherAutoBranchConfigForHostname } from "../../utils/gatherAutoBranchConfigForHostname.js";
 import { getSchemaForUnionOfAutoBranch } from "../../utils/getSchemaForUnionOfAutoBranch.js";
+import { getSimpleGit } from "../../utils/getSimpleGit.js";
 import { countTokens } from "../../utils/gptTokenizer.js";
 import { isOnline } from "../../utils/isOnline.js";
 import { ChatMessage, LLMChat } from "../../utils/LLMChat.js";
@@ -222,7 +222,7 @@ Ticket Description: "${issue.description}"
     }
 
     private async handleUserDecision(branchName: string, chat: LLMChat) {
-        const git = simpleGit();
+        const git = getSimpleGit();
         this.log(chalk.blue("\n🤖 Suggested branch name:"));
         this.log(`   ${chalk.green(branchName)}\n`);
 

--- a/src/commands/auto-commit/index.ts
+++ b/src/commands/auto-commit/index.ts
@@ -1,6 +1,5 @@
 import { Flags } from "@oclif/core";
 import chalk from "chalk";
-import { simpleGit } from "simple-git";
 
 import { BaseCommand } from "../../base-commands/BaseCommand.js";
 import { renderCommitMessageInput } from "../../ui/CommitMessageInput.js";
@@ -13,6 +12,7 @@ import { promptForTextConfigValue } from "../../utils/config/promptForConfigValu
 import { saveGatheredSettings } from "../../utils/config/saveGatheredSettings.js";
 import { loadMergedUserConfig } from "../../utils/config/userConfigHelpers.js";
 import { diffAnalyzer, DiffAnalyzerParams } from "../../utils/diffAnalyzer.js";
+import { getSimpleGit } from "../../utils/getSimpleGit.js";
 import { countTokens } from "../../utils/gptTokenizer.js";
 import { isOnline } from "../../utils/isOnline.js";
 import { ChatMessage, LLMChat } from "../../utils/LLMChat.js";
@@ -140,7 +140,7 @@ export default class AutoCommitCommand extends BaseCommand<typeof AutoCommitComm
         examples: string[],
         instructions: string,
     }) {
-        const git = simpleGit();
+        const git = getSimpleGit();
         const branchSummary = await git.branch();
         const currentBranch = branchSummary.current;
 
@@ -183,7 +183,7 @@ Diffs of Staged Files:
     }
 
     private async finalizeCommit(commitMessage: string | string[], rewordCommitHash?: string) {
-        const git = simpleGit();
+        const git = getSimpleGit();
 
         await (rewordCommitHash ? rewordCommit(rewordCommitHash, commitMessage) : git.commit(commitMessage));
     }

--- a/src/utils/checkIfCommitExists.ts
+++ b/src/utils/checkIfCommitExists.ts
@@ -1,7 +1,7 @@
-import { simpleGit } from 'simple-git';
+import { getSimpleGit } from "./getSimpleGit.js";
 
 export async function checkIfCommitExists(hash: string) {
-    const git = simpleGit();
+    const git = getSimpleGit();
 
     try {
         await git.revparse([hash]);

--- a/src/utils/checkIfFilesStaged.ts
+++ b/src/utils/checkIfFilesStaged.ts
@@ -1,7 +1,7 @@
-import { simpleGit } from "simple-git";
+import { getSimpleGit } from "./getSimpleGit.js";
 
 export async function checkIfFilesStaged() {
-    const git = simpleGit();
+    const git = getSimpleGit();
     const diff = await git.diff([ '--cached']);
 
     return diff.trim().length > 0;

--- a/src/utils/checkIfInGitRepository.ts
+++ b/src/utils/checkIfInGitRepository.ts
@@ -1,10 +1,9 @@
-import { simpleGit } from "simple-git";
-
 import { BaseCommand } from "../base-commands/BaseCommand.js";
+import { getSimpleGit } from "./getSimpleGit.js";
 import * as LOGGER from "./logging.js";
 
 export async function checkIfInGitRepository(ctx: BaseCommand) {
-    const git = simpleGit();
+    const git = getSimpleGit();
 
     const isRepository = await git.checkIsRepo();
     if(!isRepository) {

--- a/src/utils/diffAnalyzer.ts
+++ b/src/utils/diffAnalyzer.ts
@@ -1,9 +1,8 @@
-import { simpleGit } from "simple-git";
-
+import { getSimpleGit } from "./getSimpleGit.js";
 import { decode, encode, isWithinTokenLimit } from "./gptTokenizer.js";
 
 async function diffFilesPerType(params: DiffAnalyzerParams) {
-    const git = simpleGit();
+    const git = getSimpleGit();
     const isStaged = params.type === "commit";
     const baseArgs = isStaged
         ? ["diff", "--cached"]

--- a/src/utils/getRepositoryRootPath.ts
+++ b/src/utils/getRepositoryRootPath.ts
@@ -1,7 +1,7 @@
-import { simpleGit } from "simple-git";
+import { getSimpleGit } from "./getSimpleGit.js";
 
 export function getRepositoryRootPath() {
-    const git = simpleGit();
+    const git = getSimpleGit();
 
     return git.revparse(["--show-toplevel"]);
 }

--- a/src/utils/getSimpleGit.ts
+++ b/src/utils/getSimpleGit.ts
@@ -1,0 +1,11 @@
+import { simpleGit, type SimpleGit } from "simple-git";
+
+let gitInstance: null | SimpleGit = null;
+
+export function getSimpleGit(): SimpleGit {
+    if (!gitInstance) {
+        gitInstance = simpleGit()
+    }
+
+    return gitInstance;
+}

--- a/src/utils/rewordCommitMessage.ts
+++ b/src/utils/rewordCommitMessage.ts
@@ -1,7 +1,8 @@
 import { rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { simpleGit } from "simple-git";
+
+import { getSimpleGit } from "./getSimpleGit.js";
 
 /**
  * Reword an arbitrary commit in a Git repository non-interactively using 'git rebase -i'.
@@ -13,7 +14,7 @@ export async function rewordCommit(
     commitHash: string,
     newMessage: string | string[]
 ) {
-    const git = simpleGit();
+    const git = getSimpleGit();
 
     const formattedMessage = Array.isArray(newMessage) ? newMessage.join("\n") : newMessage;
     const commitHashPrefix = commitHash.slice(0, 7);


### PR DESCRIPTION
 - use a single git instance across commands and utils
 - simplify imports and improve performance