### PR TITLE
feat: add flag to ignore branch info

### DIFF
--- a/src/utils/branchBackground.ts
+++ b/src/utils/branchBackground.ts
@@ -3,7 +3,7 @@ import { getSimpleGit } from "./getSimpleGit.js";
 
 
 
-export async function getBranchBackground() {
+export async function getBranchBackground(): Promise<IssueSummary | null> {
     const git = getSimpleGit();
 
     const branch = (await git.branch()).current;


### PR DESCRIPTION
Allows auto‑commit to skip branch background when not relevant, preventing inaccurate commit messages.