### PR TITLE
fix: support CJS configs and improve compatibility

### DIFF
--- a/src/types/ConfigurationFile.ts
+++ b/src/types/ConfigurationFile.ts
@@ -1,7 +1,7 @@
 import { SUPPORTED_CONFIG_EXTENSIONS } from "../utils/config/constants.js";
 
-// eslint-disable-next-line perfectionist/sort-union-types
-export type ConfigurationFileExtensionRecommendation = typeof SUPPORTED_CONFIG_EXTENSIONS[number] | (string & {});
+export type ConfigurationFileExtensions = typeof SUPPORTED_CONFIG_EXTENSIONS[number];
+
 export type ConfigurationFileParams = {
     rootDir: string,
     type: "global" | "local",

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -1,8 +1,8 @@
 /**
  * List of supported configuration file extensions.
- * @type {readonly ["js", "json", "yaml", "yml", "toml"]}
+ * @type {readonly ["js", "json", "yaml", "yml", "toml", "mjs", "cjs"]}
  */
-export const SUPPORTED_CONFIG_EXTENSIONS = ["js", "json", "yaml", "yml", "toml"] as const;
+export const SUPPORTED_CONFIG_EXTENSIONS = ["js", "json", "yaml", "yml", "toml", "mjs", "cjs"] as const;
 
 /**
  * Generates a fallback configuration file name for a given config ID.

--- a/src/utils/config/readUserConfig.ts
+++ b/src/utils/config/readUserConfig.ts
@@ -1,13 +1,16 @@
 import { load as yamlLoad } from 'js-yaml';
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import toml from "toml";
 
 import { BaseCommand } from "../../base-commands/BaseCommand.js";
-import { ConfigurationFileExtensionRecommendation, ConfigurationFileParams } from "../../types/ConfigurationFile.js";
+import { ConfigurationFileExtensions, ConfigurationFileParams } from "../../types/ConfigurationFile.js";
 import * as LOGGER from "../logging.js";
 import { getUserConfigFilePath } from "./getUserConfigFilePath.js";
+
+const require = createRequire(import.meta.url);
 
 /**
  * Find and load a user config file of various formats in the specified directory.
@@ -29,36 +32,57 @@ export async function readUserConfig<T extends object>(ctx: BaseCommand, params:
 }
 
 async function loadConfig<T extends object>(ctx: BaseCommand, configPath: string) {
-    const ext = path.extname(configPath).slice(1) as ConfigurationFileExtensionRecommendation;
+    const ext = path.extname(configPath).slice(1) as ConfigurationFileExtensions;
 
-    if (ext === "js") {
-        try {
-            // Try ESM import
-            const mod = await import(pathToFileURL(configPath).href);
-            return (mod.default ?? mod) as T;
-        } catch (error) {
-            LOGGER.fatal(ctx, `Could not load JS config "${configPath}": ${error}`);
+    switch (ext) {
+        case "cjs":
+        case "js":
+        case "mjs": {
+            return loadJsConfig<T>(ctx, configPath);
+        }
+
+        case "json": {
+            const data = fs.readFileSync(configPath, "utf8");
+            return JSON.parse(data) as T;
+        }
+
+        case "toml": {
+            const data = fs.readFileSync(configPath, "utf8");
+            return toml.parse(data) as T;
+        }
+
+        case "yaml":
+        case "yml": {
+            const data = fs.readFileSync(configPath, "utf8");
+            return yamlLoad(data) as T;
+        }
+
+        default: {
+            LOGGER.fatal(ctx, `Unsupported config format found: ${ext satisfies never}. File: ${configPath}`);
         }
     }
+}
 
-    // --- JSON ---
-    if (ext === "json") {
-        const data = fs.readFileSync(configPath, "utf8");
-        return JSON.parse(data) as T;
+async function loadJsConfig<T>(ctx: BaseCommand, configPath: string): Promise<null | T> {
+    const fileUrl = pathToFileURL(configPath).href;
+
+    // Try ESM
+    try {
+        const mod = await import(fileUrl);
+        return (mod.default ?? mod) as T;
+    } catch (esmError) {
+        try {
+            const mod = require(configPath);
+            return mod.default ?? mod;
+        } catch (cjsError) {
+            LOGGER.fatal(
+                ctx,
+                `Could not load JS config "${configPath}". Tried ESM and CommonJS.\n` +
+                `ESM error: ${esmError}\n` +
+                `CJS error: ${cjsError}`
+            );
+
+            return null;
+        }
     }
-
-    // --- YAML ---
-    if (ext === "yaml" || ext === "yml") {
-        const data = fs.readFileSync(configPath, "utf8");
-        return yamlLoad(data) as T;
-    }
-
-    // --- TOML ---
-    if (ext === "toml") {
-        const data = fs.readFileSync(configPath, "utf8");
-        return toml.parse(data) as T;
-    }
-
-    // This case should be unreachable if CONFIG_FILENAMES is correctly derived from SUPPORTED_EXTENSIONS
-    LOGGER.fatal(ctx, `Unsupported config format found: ${ext}. File: ${configPath}`);
 }


### PR DESCRIPTION
Add handling for .cjs and .mjs files, switch default export to module.exports for better compatibility with non‑ESM modules, and extend supported config extensions.

Closes: #69